### PR TITLE
aleth.dockerfile: run testeth as non-root user

### DIFF
--- a/scripts/docker/aleth.dockerfile
+++ b/scripts/docker/aleth.dockerfile
@@ -23,7 +23,9 @@ RUN make -j $(nproc) && make install
 #     docker build --target testeth -f scripts/docker/aleth.dockerfile .
 
 FROM alpine:latest AS testeth
+RUN adduser -D testeth
 RUN apk add --no-cache libstdc++
+USER testeth
 COPY --from=builder /build/test/testeth /usr/bin/
 ENTRYPOINT ["/usr/bin/testeth"]
 


### PR DESCRIPTION
For `testeth`, there is no need to run it as root. So, now making it run as non-root user.