### PR TITLE
build.docker(aleth.dockerfile/testeth): include lllc

### DIFF
--- a/scripts/docker/aleth.dockerfile
+++ b/scripts/docker/aleth.dockerfile
@@ -26,6 +26,7 @@ FROM alpine:latest AS testeth
 RUN adduser -D testeth
 RUN apk add --no-cache libstdc++
 USER testeth
+COPY --from=lllc /usr/bin/lllc /usr/bin/lllc
 COPY --from=builder /build/test/testeth /usr/bin/
 ENTRYPOINT ["/usr/bin/testeth"]
 


### PR DESCRIPTION
testeth requires `lllc` to work while testeth docker image won't include `lllc` before this commit.