### PR TITLE
[INTERNAL] fix(libtesteth/ImportTest): problematic jsontrace output

### DIFF
--- a/test/tools/libtesteth/ImportTest.cpp
+++ b/test/tools/libtesteth/ImportTest.cpp
@@ -287,7 +287,7 @@ std::tuple<eth::State, ImportTest::ExecOutput, eth::ChangeLog> ImportTest::execu
             st.setOptions(Options::get().jsontraceOptions);
             out = initialState.execute(_env, *se.get(), _tr, Permanence::Committed, st.onOp());
             cout << st.multilineTrace();
-            cout << "{\"stateRoot\": \"" << initialState.rootHash().hex() << "\"}";
+            cout << "{\"stateRoot\": \"" << initialState.rootHash().hex() << "\"}" << endl;
         }
         else
             out = initialState.execute(_env, *se.get(), _tr, Permanence::Uncommitted);


### PR DESCRIPTION
This fixes the problem that sometimes more than one json trace object is being printed to the same line while it's expected that one line per json trace object.